### PR TITLE
Allow user to set position of author and personal info

### DIFF
--- a/src/resume.typ
+++ b/src/resume.typ
@@ -2,6 +2,8 @@
 
 #let resume(
   author: "",
+  author-position: left,
+  personal-info-position: left,
   pronouns: "",
   location: "",
   email: "",
@@ -56,7 +58,7 @@
 
   // Name will be aligned left, bold and big
   show heading.where(level: 1): it => [
-    #set align(left)
+    #set align(author-position)
     #set text(
       weight: 700,
       size: 20pt,
@@ -81,7 +83,7 @@
   // Personal Info
   pad(
     top: 0.25em,
-    align(left)[
+    align(personal-info-position)[
       #{
         let items = (
           contact-item(pronouns),


### PR DESCRIPTION
Proposed fix for an issue mentioned on the Typst forum regarding a user being unable to center the author name or personal info on their working document.

https://forum.typst.app/t/center-name-and-info-in-basic-resume/2165