### PR TITLE
Use en dash for date ranges

### DIFF
--- a/src/resume.typ
+++ b/src/resume.typ
@@ -137,7 +137,7 @@
   start-date: "",
   end-date: "",
 ) = {
-  start-date + " " + $dash.em$ + " " + end-date
+  start-date + $dash.en$ + end-date
 }
 
 // Section components below


### PR DESCRIPTION
First off, thanks for this awesome template! I wanted to make a quick fix: date ranges typically use an en dash with no space around the dates.